### PR TITLE
add parameter dataType to ton_rawSign

### DIFF
--- a/src/js/Controller.js
+++ b/src/js/Controller.js
@@ -121,6 +121,15 @@ const ACCOUNT_NUMBER = 0;
 const DEFAULT_WALLET_VERSION = 'v3R2';
 const DEFAULT_LEDGER_WALLET_VERSION = 'v3R1';
 
+/**
+ * @param {string} data
+ * @returns {boolean}
+ */
+function isHexString(data) {
+    return typeof data === 'string'
+        && !!data.match(/^[\da-fA-F]+$/);
+}
+
 class Controller {
     constructor() {
         this.isTestnet = false;
@@ -809,29 +818,33 @@ class Controller {
     }
 
     /**
-     * @param hexToSign  {string} hex data to sign
+     * @param data {string} data to sign
+     * @param dataType {string} type of signing data
      * @param needQueue {boolean}
      * @returns {Promise<string>} signature in hex
      */
-    showSignConfirm(hexToSign, needQueue) {
+    showSignConfirm(data, dataType, needQueue) {
         return new Promise((resolve, reject) => {
             if (this.isLedger) {
                 alert('sign not supported by Ledger');
                 reject();
             } else {
+                if (dataType === 'hex' && !isHexString(data)) {
+                    reject(new Error('Hexadecimal string contains non-hex character'));
+                    return;
+                }
 
                 this.afterEnterPassword = async words => {
                     this.sendToView('closePopup');
                     const privateKey = await Controller.wordsToPrivateKey(words);
-                    const signature = this.rawSign(hexToSign, privateKey);
+                    const signature = this.rawSign(data, dataType, privateKey);
                     resolve(signature);
                 };
 
                 this.sendToView('showPopup', {
                     name: 'signConfirm',
-                    data: hexToSign,
+                    data: data,
                 }, needQueue);
-
             }
         });
     }
@@ -907,13 +920,19 @@ class Controller {
     }
 
     /**
-     * @param hex   {string} hex to sign
+     * @param data {string} data to sign
+     * @param dataType {string} type of signing
      * @param privateKey    {string}
      * @returns {Promise<string>} signature in hex
      */
-    rawSign(hex, privateKey) {
+    rawSign(data, dataType, privateKey) {
+        const signingData = dataType === 'text'
+            ? new TextEncoder().encode(data)
+            : TonWeb.utils.hexToBytes(data);
+
         const keyPair = nacl.sign.keyPair.fromSeed(TonWeb.utils.base64ToBytes(privateKey));
-        const signature = nacl.sign.detached(TonWeb.utils.hexToBytes(hex), keyPair.secretKey);
+        const signature = nacl.sign.detached(signingData, keyPair.secretKey);
+
         return TonWeb.utils.bytesToHex(signature);
     }
 
@@ -1183,7 +1202,7 @@ class Controller {
                 const signParam = params[0];
                 await showExtensionWindow();
 
-                return this.showSignConfirm(signParam.data, needQueue);
+                return this.showSignConfirm(signParam.data, signParam.dataType || 'hex', needQueue);
             case 'flushMemoryCache':
                 await chrome.webRequest.handlerBehaviorChanged();
                 return true;
@@ -1206,13 +1225,28 @@ if (IS_EXTENSION) {
 
                 if (!msg.message) return;
 
-                const result = await controller.onDappMessage(msg.message.method, msg.message.params);
-                if (port) {
-                    port.postMessage(JSON.stringify({
-                        type: 'gramWalletAPI',
-                        message: {jsonrpc: '2.0', id: msg.message.id, method: msg.message.method, result}
-                    }));
+                const response = {
+                    jsonrpc: '2.0',
+                    id: msg.message.id,
+                    method: msg.message.method,
+                };
+
+                try {
+                    response.result = await controller.onDappMessage(msg.message.method, msg.message.params);
+                } catch (error) {
+                    response.error = {
+                        code: error.code,
+                        message: error.message,
+                    };
+                } finally {
+                    if (port) {
+                        port.postMessage(JSON.stringify({
+                            type: 'gramWalletAPI',
+                            message: response,
+                        }));
+                    }
                 }
+
             });
             port.onDisconnect.addListener(port => {
                 contentScriptPorts.delete(port)

--- a/src/js/extension/provider.js
+++ b/src/js/extension/provider.js
@@ -1,5 +1,13 @@
 // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1193.md#sample-class-implementation
 (() => {
+    class TonProviderError extends Error {
+        constructor(message, code) {
+            super(message);
+            this.code = code;
+            this.name = 'TonProviderError';
+        }
+    }
+
     class TonProvider {
         constructor() {
             this.listeners = window.ton ? window.ton.listeners : {};
@@ -125,10 +133,8 @@
                 const promise = this._promises[id];
                 if (promise) {
                     // Handle pending promise
-                    if (data.type === 'error') {
-                        promise.reject(message);
-                    } else if (message.error) {
-                        promise.reject(error);
+                    if (error) {
+                        promise.reject(new TonProviderError(error.message, error.code));
                     } else {
                         promise.resolve(result);
                     }


### PR DESCRIPTION
Message signing is a common approach for Web3 authentication.

Usually, it's the signing of human-readable messages (e.g., `Welcome to yyy! Nonce: zzz`).
Unfortunately, TON Wallet doesn't let developers do it without converting a message to a hexadecimal string.
On the other hand, signing a hexadecimal string is non-obvious (because a user doesn't understand what will be signed).

The following changes were made to solve the mentioned problem.

Introduced a new parameter `dataType` to method `ton_rawSing`.
Data type can be either `hex` (default) or `text`.

Additional changes:

* Implemented proper handling errors to deliver an error to a JSON-RPC client
* Added validation of input data for dataType = `hex`